### PR TITLE
feat(vm): support auto pause and resume vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@oomol-lab/mac-power-monitor": "^1.0.0",
     "adm-zip": "^0.5.10",
     "node-ssh": "^13.1.0",
     "remitter": "^0.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,13 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@oomol-lab/mac-power-monitor':
+    specifier: ^1.0.0
+    version: 1.0.0
   adm-zip:
     specifier: ^0.5.10
     version: 0.5.10
@@ -410,6 +413,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@oomol-lab/mac-power-monitor@1.0.0:
+    resolution: {integrity: sha512-KseIQ3F68QXXWbD79kD9o4d3lsvH+SCvbBKZ/LzS/LyLUcpbxe57tTp5/4vCsTHaXORNX1pqxmOFqWWlHnzCJQ==}
+    dev: false
 
   /@oomol-lab/tsconfig@0.0.1:
     resolution: {integrity: sha512-T45eJq+qKK6++ccNORZ3XyFRJ5MOf6dqazFcgx8SP4yJTJ5EsQhg0sECLI1hRsakjW6N1NxOCuQ4Z+XU37FPSQ==}

--- a/src/type.ts
+++ b/src/type.ts
@@ -14,10 +14,36 @@ export interface OVMDarwinOptions {
 export interface OVMEventData {
     ready: void,
     close: void,
+    vmPause: void,
+    vmResume: void,
     error: Error,
 }
 
 export interface OVMInfo {
     podmanPort: number;
     sshPort: number;
+}
+
+/**
+ * @see https://github.com/Code-Hex/vz/blob/bd29a7ea3d39465c4224bfb01e990e8c220a8449/virtualization.go#L23
+ */
+export enum OVMVfkitState {
+    VirtualMachineStateStopped = "VirtualMachineStateStopped",
+    VirtualMachineStateRunning = "VirtualMachineStateRunning",
+    VirtualMachineStatePaused = "VirtualMachineStatePaused",
+    VirtualMachineStateError = "VirtualMachineStateError",
+    VirtualMachineStateStarting = "VirtualMachineStateStarting",
+    VirtualMachineStatePausing = "VirtualMachineStatePausing",
+    VirtualMachineStateResuming = "VirtualMachineStateResuming",
+    VirtualMachineStateStopping = "VirtualMachineStateStopping",
+    VirtualMachineStateSaving = "VirtualMachineStateSaving",
+    VirtualMachineStateRestoring = "VirtualMachineStateRestoring",
+}
+
+export interface OVMVfkitFullState {
+    state: OVMVfkitState;
+    canPause: boolean;
+    canResume: boolean;
+    canStop: boolean;
+    canHardStop: boolean;
 }


### PR DESCRIPTION
In macOS system, if the computer goes into sleep mode, the virtual machine kernel will crash after 30 ~ 40 minutes, and the issue is related to the CPU clock. To avoid this problem, we need to pause the virtual machine when the system goes to sleep, and resume the virtual machine when the system wakes up.

Although vfkit provides the `--timesync` interface, unfortunately, the virtual machine relies on qemu-ga and can only sync the virtual machine time, unable to solve the issue of kernel crashes.

Deps:
* https://github.com/crc-org/vfkit/pull/63
* https://github.com/oomol-lab/ovm-osx-toolchain/pull/1
* https://github.com/oomol-lab/ovm-osx-toolchain/pull/3

TODO:
* After the virtual machine is awakened, we need to set the time of the virtual machine and restart the `ntp` or `chrony` service of the virtual machine. (See: https://github.com/oomol-lab/ovm-js/issues/6)
