### PR TITLE
perf(kernel_cmdline): disable fb_tunnels

### DIFF
--- a/src/darwin.ts
+++ b/src/darwin.ts
@@ -236,7 +236,7 @@ export class DarwinOVM {
             "--cpus", `${Math.floor(os.cpus().length / 2)}`,
             "--memory", "2048",
             "--restful-uri", `unix://${this.socket.vfkitRestful}`,
-            "--bootloader", `linux,kernel=${this.path.kernel},initrd=${this.path.initrd},cmdline="\\"root=/dev/vda\\""`,
+            "--bootloader", `linux,kernel=${this.path.kernel},initrd=${this.path.initrd},cmdline="root=/dev/vda fb_tunnels=none"`,
             "--device", `virtio-blk,path=${this.path.rootfs}`,
             "--device", `virtio-vsock,port=1024,socketURL=${this.socket.vfkit}`,
             "--device", "virtio-fs,sharedDir=/Users/,mountTag=vfkit-share-user",


### PR DESCRIPTION
disable the creation of useless network interfaces. e.g.
1. tunl0@NONE
2. ip_vti0@NONE
3. sit0@NONE
4. ...

Before:

![before](https://github.com/oomol-lab/ovm-js/assets/8198408/08ef5e3b-caba-402f-a2ce-af6b22acc1ea)

After:

![after](https://github.com/oomol-lab/ovm-js/assets/8198408/b6190101-3817-4c75-abeb-77383880524f)


Ref:
1. https://lore.kernel.org/netdev/20180308205141.77868-1-edumazet@google.com/T/#u
2. https://lore.kernel.org/all/20200826160535.1460065-1-maheshb@google.com/T/#u