### PR TITLE
docs(readme): remove todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ yarn add @oomol-lab/ovm
 npm install @oomol-lab/ovm
 ```
 
-## TODO
-
-* Automatic expansion for btrfs
-
 ## Usage
 
 ### Simple Example


### PR DESCRIPTION
Since we are now using overlay, automatic expansion of btrfs is no longer needed. For more details, please refer to: https://github.com/oomol-lab/ovm-core/pull/31