### PR TITLE
refactor(vfkit): add random number generator

### DIFF
--- a/src/darwin.ts
+++ b/src/darwin.ts
@@ -333,6 +333,7 @@ export class DarwinOVM {
             ...Mount.toVFKit(),
             "--device", `virtio-blk,path=${this.options.targetDir}/tmp.img`,
             "--device", `virtio-blk,path=${this.options.targetDir}/data.img`,
+            "--device", "virtio-rng",
             "--disable-orphan-process",
         ], {
             timeout: 0,


### PR DESCRIPTION
In Apple ARM machines, if the entropy in the virtual machine is insufficient, it will cause mkfs.btrfs to be very slow (taking approximately 6~12 seconds). It will be much faster (less than 1 second) by passing the entropy from the host machine to the virtual machine.